### PR TITLE
Add MKP Server to Cloud Platforms section

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [LlamaCloud](https://github.com/run-llama/mcp-server-llamacloud) - A MCP server connecting to managed indexes on LlamaCloud
 - [manusa/Kubernetes MCP Server](https://github.com/manusa/kubernetes-mcp-server) - Model Context Protocol (MCP) server for Kubernetes and OpenShift
 - [MCP Kubernetes Go](https://github.com/strowk/mcp-k8s-go) - MCP server connecting to Kubernetes
-- [MKP](https://github.com/StacklokLabs/mkp) - Model Kontext Protocol Server for Kubernetes that allows LLM-powered applications to interact with Kubernetes clusters through native Go implementation with direct API integration
+- [MKP](https://github.com/StacklokLabs/mkp) - Model Kontext Protocol server for Kubernetes; native Go implementation with direct API integration, resource management, and rate limiting
 
 ### Cloud Storage
 

--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [LlamaCloud](https://github.com/run-llama/mcp-server-llamacloud) - A MCP server connecting to managed indexes on LlamaCloud
 - [manusa/Kubernetes MCP Server](https://github.com/manusa/kubernetes-mcp-server) - Model Context Protocol (MCP) server for Kubernetes and OpenShift
 - [MCP Kubernetes Go](https://github.com/strowk/mcp-k8s-go) - MCP server connecting to Kubernetes
+- [MKP](https://github.com/StacklokLabs/mkp) - Model Kontext Protocol Server for Kubernetes that allows LLM-powered applications to interact with Kubernetes clusters through native Go implementation with direct API integration
 
 ### Cloud Storage
 


### PR DESCRIPTION
Add MKP (Model Kontext Protocol Server for Kubernetes) to the Cloud Platforms section of the README.md.

MKP is a native Go implementation that allows LLM-powered applications to interact with Kubernetes clusters through direct API integration, providing comprehensive resource management capabilities including:

- List resources supported by the Kubernetes API server
- List clustered and namespaced resources  
- Get resources and their subresources (including status, scale, logs, etc.)
- Apply (create or update) clustered and namespaced resources
- Execute commands in pods with timeout control
- Generic and pluggable implementation using API Machinery's unstructured client
- Built-in rate limiting for protection against excessive API calls

Repository: https://github.com/StacklokLabs/mkp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added information about "MKP" as a Model Kontext Protocol Server for Kubernetes under the "Cloud Platforms" section in the README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->