### PR TITLE
Add BGPT MCP to Research and Data section

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 
 - [ArXiv MCP Assistant](https://github.com/blazickjp/arxiv-mcp-server) - A Model Context Protocol server for searching and analyzing arXiv papers
 - [ArXiv MCP Server](https://github.com/andybrandt/mcp-simple-arxiv) - Tool to  work with arXiv, provide LLM with ability to search and read papers from there
+- [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) - Search scientific papers with structured experimental data extracted from full-text studies, returning 25+ fields per paper including methods, results, sample sizes, and quality scores
 - [DeepResearch Assistant](https://github.com/reading-plus-ai/mcp-server-deep-research) - Generates comprehensive, well-cited research reports from a given research question
 - [Oorlogsbronnen AI](https://github.com/r-huijts/oorlogsbronnen-mcp) - MCP server for accessing Dutch World War II archives through the Oorlogsbronnen API. Provides structured access to historical records, photographs, and documents from 1940-1945 Netherlands.
 - [SimplePubMed](https://github.com/andybrandt/mcp-simple-pubmed) - MCP server for searching and querying PubMed medical papers/research database


### PR DESCRIPTION
## Summary

Adds [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) to the Research and Data section.

BGPT MCP enables searching scientific papers and retrieving structured experimental data extracted from full-text studies. Each result returns 25+ fields including methods, results, sample sizes, limitations, and quality scores.

## Changes

- Added BGPT MCP entry to the Research and Data section in `README.md`, alphabetically after ArXiv entries
- Follows existing formatting conventions

**GitHub**: https://github.com/connerlambden/bgpt-mcp
**Website**: https://bgpt.pro/mcp



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added BGPT MCP server entry to the Research and Data section, detailing its capability to return 25+ fields per paper including methods, results, sample sizes, and quality scores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->