### PR TITLE
Add Velixar Memory MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [Notion](https://github.com/v-3/notion-server) - Seamlessly integrates language models with Notion workspaces for searching, creating, updating, and managing pages and databases
 - [Obsidian Markdown Notes](https://github.com/calclavia/mcp-obsidian) - A connector for Claude Desktop to read and search an Obsidian vault.
 - [PIF](https://github.com/hungryrobot1/MCP-PIF) - A MCP implementation of the personal intelligence framework (PIF)
+- [Velixar Memory](https://github.com/VelixarAi/velixar-mcp-server) - Persistent memory for AI assistants across sessions. Store, search, list, update, and delete memories with semantic search, tiered storage (pinned/session/semantic/org), and auto-recall. Works with Claude Desktop, Kiro, Cursor, Windsurf, and any MCP client.
 - [XMind](https://github.com/apeyroux/mcp-xmind) - Analyzes and queries XMind mind maps, enabling smart searches, task management, and multi-file analysis
 
 ### Location Services


### PR DESCRIPTION
Adds [Velixar Memory](https://github.com/VelixarAi/velixar-mcp-server) to the Knowledge and Memory section.

**What it does:** Persistent memory for AI assistants across sessions. 5 tools: store, search, list, update, delete. Semantic search, tiered storage (pinned/session/semantic/org), auto-recall via MCP resources.

**npm:** `npm install -g velixar-mcp-server`
**License:** MIT
**Tested with:** Claude Desktop, Kiro, Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Velixar Memory MCP server documentation with capabilities including persistent memory across sessions, semantic search, tiered storage, and auto-recall features, compatible with multiple client integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->