### PR TITLE
Add Resolve MCP Server to Monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [Grafana MCP](https://github.com/grafana/mcp-grafana) - Provides programmatic access to Grafana dashboards, data sources, and alerting features via the Model Context Protocol
 - [Logfire Telemetry Analyzer](https://github.com/pydantic/logfire-mcp) - The Logfire MCP Server is here! :tada:
 - [Raygun MCP Server](https://github.com/MindscapeHQ/mcp-server-raygun) - Provides API access to Raygun's crash reporting and real user monitoring features via the Model Context Protocol
+- [Resolve MCP](https://github.com/unitedideas/resolve-mcp) - Structured error recovery for AI agents. Returns resolution playbooks (backoff schedules, retry strategies, recovery steps) for 20+ services including OpenAI, Anthropic, Stripe, AWS, Postgres, and more. Free tier: 500 requests/month.
 - [MCP System Monitor](https://github.com/seekrays/mcp-monitor) - A system monitoring tool that exposes system metrics via the Model Context Protocol (MCP). This tool allows LLMs to retrieve real-time system information through an MCP-compatible interface.
 
 ### Note Taking


### PR DESCRIPTION
Adds [Resolve MCP Server](https://github.com/unitedideas/resolve-mcp) to the Monitoring section.

**What it does:** Structured error recovery for AI agents. Returns resolution playbooks (backoff schedules, retry strategies, recovery steps) for 20+ services including OpenAI, Anthropic, Stripe, AWS, Postgres, and more.

**Free tier:** 500 requests/month.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Resolve MCP to the Monitoring section, a new error recovery tool for AI agents supporting 20+ services with a free tier option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->