### PR TITLE
Add operant-mcp to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [MCP Security Auditor](https://github.com/qianniuspace/mcp-security-audit) - A powerful MCP (Model Context Protocol) Server that audits npm package dependencies for security vulnerabilities. Built with remote npm registry integration for real-time security checks.
 - [Okta](https://github.com/kapilduraphe/okta-mcp-server) - Manages Okta users and groups via a Claude-integrated server
 - [OpenCTI](https://github.com/Spathodea-Network/opencti-mcp) - A Model Context Protocol (MCP) server providing standardized access to OpenCTI threat intelligence data
+- [operant-mcp](https://github.com/operantlabs/operant-mcp) - Security testing MCP server with 51 tools for penetration testing, network forensics, memory analysis, and vulnerability assessment.
 - [ORKL MCP Server](https://github.com/fr0gger/MCP_Security) - This is a repository to experiment with MCP for security
 - [SafePythonExecutor](https://github.com/maxim-saplin/mcp_safe_local_python_executor) - Stdio MCP Server wrapping custom Python runtime (LocalPythonExecutor) from Hugging Faces' `smolagents` framework. The runtime combines the ease of setup (compared to docker, VM, cloud runtimes) while providing safeguards and limiting operations/imports that are allowed inside the runtime.
 - [Solana Rug Check](https://github.com/kukapay/rug-check-mcp) - An MCP server that detects potential risks in Solana meme tokens.


### PR DESCRIPTION
## Summary
- Adds [operant-mcp](https://github.com/operantlabs/operant-mcp) to the Security section
- Security testing MCP server with 51 tools for penetration testing, network forensics, memory analysis, and vulnerability assessment
- TypeScript, MIT license

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for a new security testing MCP server featuring 51 tools for penetration testing, network forensics, memory analysis, and vulnerability assessment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->