### PR TITLE
Add Toolradar MCP to Search section

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,6 +565,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [Typesense](https://github.com/suhail-ak-s/mcp-typesense-server) - Provides AI models with access to Typesense search capabilities for data discovery, search, and analysis
 - [Unsplash Image Server](https://github.com/hellokaton/unsplash-mcp-server) - 🔎 A MCP server for Unsplash image search.
 - [WebSearch MCP](https://github.com/pskill9/web-search) - Web search using free google search (NO API KEYS REQUIRED)
+- [Toolradar MCP](https://github.com/Nadeus/toolradar-mcp) - Search, compare, and get pricing for 8,600+ software tools with verified data, editorial scores, G2/Capterra ratings, and real alternatives
 
 ### Security
 


### PR DESCRIPTION
Adds [Toolradar MCP](https://github.com/Nadeus/toolradar-mcp) to the Search section.

**What it does:** Search, compare, and get pricing for 8,600+ software tools with verified data, editorial scores, G2/Capterra ratings, and real alternatives.

- **npm:** `toolradar-mcp`
- **Install:** `npx -y toolradar-mcp`
- **Transport:** stdio
- **Free tier:** 100 API calls/day (no key required)
- **Tools:** `search_tools`, `get_tool`, `compare_tools`, `get_alternatives`, `get_pricing`, `list_categories`
- **License:** MIT

Works with Claude Desktop, Cursor, Windsurf, and Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Toolradar MCP to the search tools catalog, enabling searches and comparisons of software tools with access to 8,600+ tools and pricing/rating data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->