### PR TITLE
Add CompanyScope MCP to Research and Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 
 - [ArXiv MCP Assistant](https://github.com/blazickjp/arxiv-mcp-server) - A Model Context Protocol server for searching and analyzing arXiv papers
 - [ArXiv MCP Server](https://github.com/andybrandt/mcp-simple-arxiv) - Tool to  work with arXiv, provide LLM with ability to search and read papers from there
+- [CompanyScope MCP](https://github.com/Stewyboy1990/companyscope-mcp) - Company intelligence from one tool call — aggregates profiles, tech stacks, funding, employees, news, and competitors from 12 free public sources
 - [DeepResearch Assistant](https://github.com/reading-plus-ai/mcp-server-deep-research) - Generates comprehensive, well-cited research reports from a given research question
 - [Oorlogsbronnen AI](https://github.com/r-huijts/oorlogsbronnen-mcp) - MCP server for accessing Dutch World War II archives through the Oorlogsbronnen API. Provides structured access to historical records, photographs, and documents from 1940-1945 Netherlands.
 - [SimplePubMed](https://github.com/andybrandt/mcp-simple-pubmed) - MCP server for searching and querying PubMed medical papers/research database


### PR DESCRIPTION
## What

Adds [CompanyScope MCP](https://github.com/Stewyboy1990/companyscope-mcp) to the Research and Data section.

## About CompanyScope MCP

Company intelligence from one tool call — full company profiles aggregated from 12 free public sources:

- **11 tools**: company profile, tech stack, funding rounds, employee search, competitor analysis, patent search, news monitoring, and more
- **12 data sources**: Wikipedia, GitHub, Brave Search, Hunter.io, OpenCorporates, and others
- **No API keys required** for core functionality
- **Multiple transports**: stdio (npm), remote HTTP (Cloudflare Workers), Apify Actor

Available on npm (`companyscope-mcp`), Official MCP Registry, Glama, Smithery, and Apify Store.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added CompanyScope MCP to the Research and Data section—a tool that aggregates company intelligence including profiles, tech stacks, funding, employees, news, and competitors from multiple free public sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->