### PR TITLE
Add Agentic Engineering Jobs MCP to Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,6 +565,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [Typesense](https://github.com/suhail-ak-s/mcp-typesense-server) - Provides AI models with access to Typesense search capabilities for data discovery, search, and analysis
 - [Unsplash Image Server](https://github.com/hellokaton/unsplash-mcp-server) - 🔎 A MCP server for Unsplash image search.
 - [WebSearch MCP](https://github.com/pskill9/web-search) - Web search using free google search (NO API KEYS REQUIRED)
+- [Agentic Engineering Jobs](https://agentic-engineering-jobs.com/mcp) - Remote MCP server for searching live agentic AI engineering jobs by framework (LangChain, LlamaIndex, CrewAI, etc.), seniority, location, and remote status. Also exposes aggregate salary benchmarks. Zero-auth streamable HTTP.
 
 ### Security
 


### PR DESCRIPTION
Adding a remote MCP server for https://agentic-engineering-jobs.com — a job board for engineers building agentic systems (LangChain, LlamaIndex, CrewAI, etc.).

- Tools: search_jobs, get_job, get_salaries
- Remote streamable HTTP, no API key
- Works with Claude Desktop, Claude Code, ChatGPT, Cursor, Windsurf

Happy to move placement or adjust the description.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new MCP server entry "Agentic Engineering Jobs" to the directory—a service for searching live AI engineering positions with filtering by framework, seniority, location, and remote status, plus salary benchmark data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->