### PR TITLE
Add Vigil MCPWatch under Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [Logfire Telemetry Analyzer](https://github.com/pydantic/logfire-mcp) - The Logfire MCP Server is here! :tada:
 - [Raygun MCP Server](https://github.com/MindscapeHQ/mcp-server-raygun) - Provides API access to Raygun's crash reporting and real user monitoring features via the Model Context Protocol
 - [MCP System Monitor](https://github.com/seekrays/mcp-monitor) - A system monitoring tool that exposes system metrics via the Model Context Protocol (MCP). This tool allows LLMs to retrieve real-time system information through an MCP-compatible interface.
+- [Vigil MCPWatch](https://github.com/AlexlaGuardia/Vigil) - One-line observability for any Python MCP server (FastMCP and low-level Server). Tracks per-tool latency (p50/p95/p99), error rates, silent failures, and call volume. REST API + CLI + alerts. MIT.
 
 ### Note Taking
 


### PR DESCRIPTION
Adds **Vigil MCPWatch** under the Monitoring section.

MCPWatch is observability for MCP servers themselves. One line wraps any Python MCP server — both `FastMCP` and the low-level `mcp.server.lowlevel.Server` — and tracks:

- Per-tool latency (p50/p95/p99)
- Error rates per tool
- Silent failures (empty/null returns + `isError` responses)
- Call volume over time

Used in production across 95+ MCP tools. MIT, no config required. REST API + CLI + alert hooks included.

- Repo: https://github.com/AlexlaGuardia/Vigil
- PyPI: https://pypi.org/project/vigil-agent/
- Article: https://dev.to/alexlaguardia/your-mcp-servers-are-flying-blind-heres-how-to-fix-it-3g51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new monitoring tool reference to the Monitoring section with associated documentation link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->