### PR TITLE
Add Trackly: AI job search MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,6 +671,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [Rootly MCP Integration](https://github.com/Rootly-AI-Labs/Rootly-MCP-server) - Integrates Rootly with MCP-compatible IDEs for rapid incident resolution
 - [Salesforce MCP Integrator](https://github.com/lciesielski/mcp-salesforce-example) - Integrates with Salesforce via the Model Context Protocol (MCP) to send emails and deploy Apex code
 - [Todoist](https://github.com/abhiz123/todoist-mcp-server) - MCP server for Todoist integration enabling natural language task management with Claude
+- [Trackly](https://github.com/kevinastuhuaman/trackly-cli) - AI job search MCP server with 128K+ openings across 1,900+ companies. 10 tools for jobs, applications, contacts, and referrals. Hosted streamable-http with OAuth 2.1 (Claude co-work, Claude Desktop, ChatGPT) or local stdio for Cursor / Windsurf / Claude Code.
 - [UserFeedbackMCP](https://github.com/mrexodia/user-feedback-mcp) - Simple MCP Server to enable a human-in-the-loop workflow in tools like Cline and Cursor.
 
 ### Other Tools and Integrations


### PR DESCRIPTION
## Summary

Adds **Trackly** to the **Workflow Automation** section (alphabetical between Todoist and UserFeedbackMCP).

Trackly is an AI job search MCP server with **128K+ live job openings across 1,900+ companies**. It exposes 10 tools for searching jobs, tracking applications, finding contacts at target companies, and orchestrating referral campaigns — designed for Claude Code, Cursor, ChatGPT, and any MCP-compatible client.

## Two connection modes

- **Hosted (recommended):** `https://mcp.usetrackly.app/api/mcp` — streamable-http transport with OAuth 2.1 (Dynamic Client Registration, PKCE).
- **Local stdio:** `npx trackly-cli mcp` — npm package `trackly-cli`, no install needed.

## Registry & package

- Official MCP Registry entry: `io.github.kevinastuhuaman/trackly`
- npm: [`trackly-cli`](https://www.npmjs.com/package/trackly-cli)
- Source: https://github.com/kevinastuhuaman/trackly-cli
- License: MIT

## Tools

`trackly_search_jobs`, `trackly_get_job`, `trackly_search_companies`, `trackly_list_companies`, `trackly_get_stats`, `trackly_update_status`, `trackly_ask`, `trackly_get_job_brief`, `trackly_contacts_at_company`, `trackly_get_company_workspace`

Entry follows the existing single-line `- [Name](url) - description` format used throughout the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added information about the Trackly server to the workflow automation documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->