### PR TITLE
Add Ejentum under AI Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [Dart](https://github.com/its-dart/dart-mcp-server) - Dart AI Model Context Protocol (MCP) server
 - [DevHub](https://github.com/devhub/devhub-cms-mcp) - DevHub CMS LLM integration through the Model Context Protocol
 - [E2B](https://github.com/e2b-dev/mcp-server) - Giving Claude ability to run code with E2B via MCP (Model Context Protocol)
-- [Ejentum](https://github.com/ejentum/ejentum-mcp) - Reasoning Harness for agentic AI: 4 MCP tools (reasoning, code, anti-deception, memory) over 679 engineered cognitive operations. Each call returns a structured scaffold the calling LLM ingests before its first token, catching sycophancy, hallucination, and reasoning decay before they emerge.
+- [Ejentum](https://github.com/ejentum/ejentum-mcp) - MCP server with four pre-prompt cognitive scaffolds for reasoning, code review, anti-deception, and memory.
 - [EduBase](https://github.com/EduBase/MCP) - The EduBase MCP server enables Claude and other LLMs to interact with EduBase's comprehensive e-learning platform through the Model Context Protocol (MCP).
 - [Exa MCP Server](https://github.com/exa-labs/exa-mcp-server) - Claude can perform Web Search | Exa with MCP (Model Context Protocol)
 - [ForeverVM](https://github.com/jamsocket/forevervm/tree/main/javascript/mcp-server) - Securely run AI-generated code in stateful sandboxes that run forever.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [Dart](https://github.com/its-dart/dart-mcp-server) - Dart AI Model Context Protocol (MCP) server
 - [DevHub](https://github.com/devhub/devhub-cms-mcp) - DevHub CMS LLM integration through the Model Context Protocol
 - [E2B](https://github.com/e2b-dev/mcp-server) - Giving Claude ability to run code with E2B via MCP (Model Context Protocol)
-- [Ejentum](https://github.com/ejentum/ejentum-mcp) - MCP server with four pre-prompt cognitive scaffolds for reasoning, code review, anti-deception, and memory.
+- [Ejentum](https://github.com/ejentum/ejentum-mcp) - MCP server with reasoning, code, anti-deception, and memory tools for AI agents.
 - [EduBase](https://github.com/EduBase/MCP) - The EduBase MCP server enables Claude and other LLMs to interact with EduBase's comprehensive e-learning platform through the Model Context Protocol (MCP).
 - [Exa MCP Server](https://github.com/exa-labs/exa-mcp-server) - Claude can perform Web Search | Exa with MCP (Model Context Protocol)
 - [ForeverVM](https://github.com/jamsocket/forevervm/tree/main/javascript/mcp-server) - Securely run AI-generated code in stateful sandboxes that run forever.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [Dart](https://github.com/its-dart/dart-mcp-server) - Dart AI Model Context Protocol (MCP) server
 - [DevHub](https://github.com/devhub/devhub-cms-mcp) - DevHub CMS LLM integration through the Model Context Protocol
 - [E2B](https://github.com/e2b-dev/mcp-server) - Giving Claude ability to run code with E2B via MCP (Model Context Protocol)
+- [Ejentum](https://github.com/ejentum/ejentum-mcp) - Reasoning Harness for agentic AI: 4 MCP tools (reasoning, code, anti-deception, memory) over 679 engineered cognitive operations. Each call returns a structured scaffold the calling LLM ingests before its first token, catching sycophancy, hallucination, and reasoning decay before they emerge.
 - [EduBase](https://github.com/EduBase/MCP) - The EduBase MCP server enables Claude and other LLMs to interact with EduBase's comprehensive e-learning platform through the Model Context Protocol (MCP).
 - [Exa MCP Server](https://github.com/exa-labs/exa-mcp-server) - Claude can perform Web Search | Exa with MCP (Model Context Protocol)
 - [ForeverVM](https://github.com/jamsocket/forevervm/tree/main/javascript/mcp-server) - Securely run AI-generated code in stateful sandboxes that run forever.


### PR DESCRIPTION
Adds `ejentum/ejentum-mcp` to the MCP servers section.

MCP server (npm `ejentum-mcp` for stdio, or remote HTTPS at `https://api.ejentum.com/mcp`, MIT) exposing four tools: `harness_reasoning`, `harness_code`, `harness_anti_deception`, `harness_memory`. Each tool returns a structured prompt that the calling agent ingests before generating.

## Compliance

- Repo public, MIT, actively maintained
- One line added, alphabetical placement verified
- Not a duplicate

Maintainer is me; happy to address review feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Ejentum to the AI Services list in the project documentation, including a GitHub link and a short description so users can discover, evaluate, and compare this newly listed AI service.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/habitoai/awesome-mcp-servers/pull/62)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->