### PR TITLE
Add Dakera to Knowledge and Memory section

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [PIF](https://github.com/hungryrobot1/MCP-PIF) - A MCP implementation of the personal intelligence framework (PIF)
 - [XMind](https://github.com/apeyroux/mcp-xmind) - Analyzes and queries XMind mind maps, enabling smart searches, task management, and multi-file analysis
 
+- [Dakera](https://github.com/Dakera-AI/dakera) - Agent memory engine with vector search, knowledge graphs, session management. 83 MCP tools, self-hosted Rust binary, zero external dependencies.
 ### Location Services
 
 - [GeoMCP](https://github.com/webcoderz/MCP-Geo) - Geocoding MCP server with GeoPY!


### PR DESCRIPTION
## Dakera MCP

[dakera-mcp](https://github.com/dakera-ai/dakera-mcp) is a self-hosted MCP-native agent memory server.

**Knowledge and Memory fit:**
- Purpose-built for persistent agent episodic memory management
- 83 MCP tools for store/recall/forget/search with configurable decay
- Self-hosted, zero cloud dependency — all memory on your infrastructure
- RocksDB + HNSW vector search backend
- Top-performing on long-term conversational memory benchmarks, multi-SDK (Python/JS/Rust/Go)
- Docker Compose deployment via dakera-ai/dakera-deploy