### PR TITLE
Add Dakera to Knowledge and Memory section

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [Anki](https://github.com/scorzeth/anki-mcp-server) - Manages and interacts with Anki flashcards via a server, enabling card creation, review, and data retrieval
 - [Apple Notes](https://github.com/RafalWilinski/mcp-apple-notes) - Talk with your notes in Claude. RAG over your Apple Notes using Model Context Protocol.
 - [Basic Memory](https://github.com/basicmachines-co/basic-memory) - Basic Memory is a knowledge management system that allows you to build a persistent semantic graph from conversations with AI assistants. All knowledge is stored in standard Markdown files on your computer, giving you full control and ownership of your data. Integrates directly with Obsidan.md
+- [Dakera MCP](https://github.com/dakera-ai/dakera-mcp) - Persistent memory and knowledge layer for AI agents with semantic search, hybrid retrieval, and multi-SDK support
 - [Goal Story](https://github.com/hichana/goalstory-mcp) - Manages aspirations through narrative-driven goal setting, powered by conversational AI for personalized motivation and progress tracking
 - [Mindmap MCP](https://github.com/YuChenSSR/mindmap-mcp-server) - mindmap, mcp server, artifact
 - [Notion](https://github.com/v-3/notion-server) - Seamlessly integrates language models with Notion workspaces for searching, creating, updating, and managing pages and databases


### PR DESCRIPTION
## Summary

Adding [Dakera MCP](https://github.com/dakera-ai/dakera-mcp) to the Knowledge and Memory section.

**Dakera MCP** is an open-source MCP server that gives AI agents persistent memory with:
- Semantic search using hybrid retrieval (BM25 + vector)
- Episodic, semantic, and procedural memory types
- Multi-agent namespacing with importance decay
- Self-hostable via Docker Compose

It implements the Model Context Protocol (MCP), is actively maintained, and has documentation at the repo.

Format follows the contributing guidelines: `[Project Name](link) - Brief description`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Dakera MCP resource entry to the Knowledge and Memory section, including its associated link and description.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/habitoai/awesome-mcp-servers/pull/68)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->