### PR TITLE
Add Sharpe MCP Server to finance MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [KukaPay Uniswap Trader](https://github.com/kukapay/uniswap-trader-mcp) - An MCP server for AI agents to automate token swaps on Uniswap DEX across multiple blockchains.
 - [LedgerAI](https://github.com/minhyeoky/mcp-server-ledger) - A Model Context Protocol server for interacting with Ledger CLI, a powerful double-entry accounting system. This server enables Large Language Models to query and analyze financial data through a standardized interface, making it easy for AI assistants to help with financial reporting, budget analysis, and accounting tasks.
 - [PancakeSwap PoolSpy](https://github.com/kukapay/pancakeswap-poolspy-mcp) - An MCP server that tracks newly created liquidity pools on Pancake Swap
+- [Sharpe MCP Server](https://www.sharpe.ai/docs/mcp-server) - Connects AI agents and MCP clients to Sharpe crypto derivatives and market data.
 - [Stripe](https://github.com/atharvagupta2003/mcp-stripe) - Manages financial transactions via Stripe, providing secure payment processing, customer management, and refund capabilities with detailed audit logging
 - [TastyTrade Agent](https://github.com/ferdousbhai/tasty-agent) - Let Claude manage your tastytrade portfolio.
 - [Uniswap PoolSpy](https://github.com/kukapay/uniswap-poolspy-mcp) - An MCP server that tracks newly created liquidity pools on Uniswap across nine blockchain networks.


### PR DESCRIPTION
## Summary
Adds Sharpe MCP Server to the Finance section.

## Fit
The Finance section already includes MCP servers for market data, crypto prices, indicators, and news sources such as CoinMarketCap Server, CoinCap Data Server, CryptoPanic News Server, and crypto indicator tools. Sharpe MCP Server fits that group as an MCP interface for crypto derivatives and market data workflows.

## Validation
- Website: https://www.sharpe.ai/docs/mcp-server
- Confirmed the docs page returns HTTP 200 on 2026-05-14.
- Checked existing open and closed PRs for Sharpe before opening this PR.

Disclosure: I'm connected with Sharpe AI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Sharpe MCP Server entry to the Finance section in README with description and reference information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/habitoai/awesome-mcp-servers/pull/69)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->