### PR TITLE
Add Dakera to Knowledge and Memory section

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [Anki](https://github.com/scorzeth/anki-mcp-server) - Manages and interacts with Anki flashcards via a server, enabling card creation, review, and data retrieval
 - [Apple Notes](https://github.com/RafalWilinski/mcp-apple-notes) - Talk with your notes in Claude. RAG over your Apple Notes using Model Context Protocol.
 - [Basic Memory](https://github.com/basicmachines-co/basic-memory) - Basic Memory is a knowledge management system that allows you to build a persistent semantic graph from conversations with AI assistants. All knowledge is stored in standard Markdown files on your computer, giving you full control and ownership of your data. Integrates directly with Obsidan.md
+- [Dakera](https://github.com/dakera-ai/dakera-deploy) - Self-hosted agent memory server with hybrid BM25 + HNSW vector retrieval, decay-weighted recall, multi-agent namespacing, and MCP integration. SDKs for Python, TypeScript, Go, and Rust.
 - [Goal Story](https://github.com/hichana/goalstory-mcp) - Manages aspirations through narrative-driven goal setting, powered by conversational AI for personalized motivation and progress tracking
 - [Mindmap MCP](https://github.com/YuChenSSR/mindmap-mcp-server) - mindmap, mcp server, artifact
 - [Notion](https://github.com/v-3/notion-server) - Seamlessly integrates language models with Notion workspaces for searching, creating, updating, and managing pages and databases


### PR DESCRIPTION
## Description

Adds [Dakera](https://github.com/dakera-ai/dakera-deploy) — a production-ready, self-hosted agent memory server.

**Key features:**
- Hybrid BM25 + HNSW vector retrieval for high-recall semantic search
- Decay-weighted recall (importance fades over time, like human memory)
- Multi-agent namespacing with per-namespace isolation
- MCP-native integration — works with Claude Code, Cursor, Windsurf, and any MCP client
- SDKs for Python, TypeScript, Go, and Rust

Open-source (Apache 2.0), self-hosted, production-ready.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about a self-hosted agent memory solution to the Knowledge and Memory section, including its repository link and MCP integration capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/habitoai/awesome-mcp-servers/pull/70)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->