### PR TITLE
Add Nevent MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 
 ### Marketing
 
+- [Nevent](https://github.com/nevent-dev/mcp-nevent) - Official MCP server for [Nevent](https://nevent.ai), the live-events CRM and marketing platform. 43 tools across analytics, segments, campaigns, templates, deliverability, paid media (Meta/Google/TikTok), and multi-tenant operations. Hosted with OAuth 2.1 at `https://mcp.nevent.ai/mcp`; stdio mode also supported.
 - [Open Strategy Partners Marketing Tools](https://github.com/open-strategy-partners/osp_marketing_tools) - A Model Context Protocol (MCP) server that empowers LLMs to use some of Open Srategy Partners' core writing and product marketing techniques.
 
 ### Monitoring


### PR DESCRIPTION
Adds the Nevent MCP server to the Marketing section.

- Repository: https://github.com/nevent-dev/mcp-nevent
- Hosted endpoint: https://mcp.nevent.ai/mcp (OAuth 2.1)
- License: MIT
- Tools: 43 across analytics, segments, campaigns, templates, deliverability, paid media (Meta/Google/TikTok), and multi-tenant operations

The server is production-deployed at `mcp.nevent.ai` and exposes a public manifest at `/.well-known/mcp-manifest.json` and OAuth metadata at `/.well-known/oauth-authorization-server`.

Tested with Claude.ai, Claude Desktop, Cursor, Cline, Continue, and ChatGPT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Nevent entry to marketing resources with link, description, hosting URL, and stdio mode support information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/habitoai/awesome-mcp-servers/pull/72?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->