### PR TITLE
feat: add evc-team-relay-mcp to Note Taking section

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 <br><br>
 
 - [BearMCP](https://github.com/akseyh/bear-mcp-server) - MCP Server integration for Bear note app
+- [EVC Team Relay MCP](https://github.com/entire-vc/evc-team-relay-mcp) - Collaborative Obsidian vault access via Team Relay — read, write, and sync notes with real-time CRDT-based conflict resolution
 - [Google Calendar](https://github.com/v-3/google-calendar) - Manages and schedules events, meetings, and free time slots
 
 ### Research and Data


### PR DESCRIPTION
Adds [evc-team-relay-mcp](https://github.com/entire-vc/evc-team-relay-mcp) to the Note Taking section.

MCP server for collaborative Obsidian vault access via Team Relay — read, write, and sync vault documents with real-time CRDT-based conflict resolution.

- PyPI: `pip install evc-team-relay-mcp` / `uvx evc-team-relay-mcp`
- License: MIT | Python | Topics: mcp-server, model-context-protocol, obsidian

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added EVC Team Relay MCP to the list of available integrations for note-taking workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/habitoai/awesome-mcp-servers/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->