### PR TITLE
Add YIELD INTELLIGENCE MCP server — Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [Uniswap PoolSpy](https://github.com/kukapay/uniswap-poolspy-mcp) - An MCP server that tracks newly created liquidity pools on Uniswap across nine blockchain networks.
 - [WhaleTracker MCP](https://github.com/kukapay/whale-tracker-mcp) - A mcp server for tracking cryptocurrency whale transactions.
 - [Yahoo Finance MCP](https://github.com/narumiruna/yfinance-mcp) - Fetches stock data, news, and financial information via a Yahoo Finance API server
+- [YIELD INTELLIGENCE](https://github.com/thebrierfox/intuitek-ace) - Passive income opportunity analysis with live US Treasury rates, portfolio yield calculator, and AI-powered income optimization. Open MCP endpoint: https://api.intuitek.ai/yield/mcp — no auth required
 - [ZBD](https://github.com/zebedeeio/zbd-mcp-server) - Enables Bitcoin Lightning payments within large language models
 
 ### Gaming


### PR DESCRIPTION
Adding YIELD INTELLIGENCE to the Finance section.

What it does: Passive income opportunity analysis with live US Treasury rates, portfolio yield calculator, and AI-powered income optimization.

Live MCP endpoint: https://api.intuitek.ai/yield/mcp (open, no auth required)

Tools: analyze_yield_opportunities, optimize_income_portfolio

Category fit: Finance — financial data and yield analysis.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added YIELD INTELLIGENCE to the Finance section of the documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/habitoai/awesome-mcp-servers/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->