### PR TITLE
Add OrbiAds Google Ad Manager MCP to Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 ### Marketing
 
 - [Open Strategy Partners Marketing Tools](https://github.com/open-strategy-partners/osp_marketing_tools) - A Model Context Protocol (MCP) server that empowers LLMs to use some of Open Srategy Partners' core writing and product marketing techniques.
+- [OrbiAds — Google Ad Manager MCP](https://github.com/OrbiAds/Orbiads-GAM-MCP) - Hosted MCP server connecting Claude, ChatGPT, Gemini, and Codex to Google Ad Manager. 200+ tools for campaigns, line items, creatives, reporting, and ad-ops audits. OAuth on-behalf-of-user, GAM API v202602, free trial at orbiads.com.
 
 ### Monitoring
 


### PR DESCRIPTION
## Adding OrbiAds — Google Ad Manager MCP

OrbiAds is a hosted MCP server connecting Claude, ChatGPT, Gemini, and OpenAI Codex directly to Google Ad Manager (the publisher-side ad-serving platform).

This complements the existing Marketing entry by covering a different audience (publishers and ad-ops teams managing GAM networks).

## Specs

- Repo: https://github.com/OrbiAds/Orbiads-GAM-MCP
- Language: Python 3.11+
- Transport: streamable-http
- Endpoint: https://orbiads.com/mcp
- Auth: OAuth 2.0 (Google on-behalf-of-user)
- GAM API: v202602
- License: open scaffold + proprietary backend

## Format compliance

- Section: Marketing
- Format: `- [Name](url) - Description.`
- Single line, alphabetical position after existing entry


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new OrbiAds — Google Ad Manager MCP server entry to the Marketing section, including details on OAuth functionality, Google Ad Manager tool coverage, and version/free-trial information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/habitoai/awesome-mcp-servers/pull/78?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->