### PR TITLE
Add SEO Performance MCP to Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 ### Marketing
 
 - [Open Strategy Partners Marketing Tools](https://github.com/open-strategy-partners/osp_marketing_tools) - A Model Context Protocol (MCP) server that empowers LLMs to use some of Open Srategy Partners' core writing and product marketing techniques.
+- [SEO Performance MCP](https://github.com/AutomateLab-tech/seo-performance-mcp) - Post-publish SEO performance server that unifies Google Search Console, GA4, Matomo, Clarity, and AI-citation signals per URL and emits a per-URL verdict (refresh, expand, merge, or kill) for every published page.
 
 ### Monitoring
 


### PR DESCRIPTION
## What

Adds [SEO Performance MCP](https://github.com/AutomateLab-tech/seo-performance-mcp) under `### Marketing`, placed alphabetically after the existing Open Strategy Partners entry.

## What it does

SEO Performance MCP is a post-publish analytics server (TypeScript, local stdio) that unifies per-URL signals from **Google Search Console, GA4, Matomo, Microsoft Clarity, and AI-citation data**, then emits a single per-URL verdict — *refresh, expand, merge, or kill* — so an AI agent can triage content decay and prioritize what to update.

- Pulls impressions, clicks, CTR, and position trends per URL from Search Console.
- Joins engagement (GA4/Matomo) and behavior (Clarity) signals to the same URL.
- Scores decay and surfaces quick wins, then recommends a concrete action per page.

## Format check

- Format: `- [Project Name](link) - Brief description` ✓
- Alphabetical placement within Marketing (after `Open Strategy Partners`) ✓
- Actively maintained, implements MCP, has documentation ✓
- Fits Marketing (SEO/content-performance) ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added SEO Performance MCP to the Marketing section, documenting a post-publish server that consolidates multiple analytics and search sources to provide per-URL verdicts for published content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->