### PR TITLE
Add ProposalCraft — MCP server for freelance proposal drafting

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 ### Marketing
 
 - [Open Strategy Partners Marketing Tools](https://github.com/open-strategy-partners/osp_marketing_tools) - A Model Context Protocol (MCP) server that empowers LLMs to use some of Open Srategy Partners' core writing and product marketing techniques.
+- [ProposalCraft](https://github.com/bradshawprojects/proposalcraft) - MCP server for freelancers that drafts proposals in your voice from your past winning work. Paste a client brief, get a ready-to-send proposal. 7 tools including brief analysis, voice-matched drafting, and template library. Install: `npx -y github:bradshawprojects/proposalcraft`
 
 ### Monitoring
 


### PR DESCRIPTION
## What is ProposalCraft?

**ProposalCraft** is an open-source MCP server that helps freelancers and consultants draft client proposals in their own voice, informed by their past winning work.

**GitHub:** https://github.com/bradshawprojects/proposalcraft  
**Landing page:** https://bradshawprojects.github.io/proposalcraft/

## Why it belongs in Marketing

ProposalCraft automates the highest-friction part of a freelancer's sales cycle: turning a client brief into a ready-to-send proposal. It fits naturally in the Marketing section alongside tools that help with outreach and client acquisition.

## Tools (7 total)

- `draft_proposal` — Drafts a proposal in your voice from a brief + past examples
- `analyze_brief` — Extracts budget signals, red flags, scope risks before drafting
- `save_proposal` / `get_proposal` / `list_proposals` / `delete_proposal` — Personal proposal library management
- `load_examples` — One-command template bootstrap for new users

## Install

```bash
npx -y github:bradshawprojects/proposalcraft
```

No API key required. Works with Claude Desktop and any MCP-compatible client.

## Checklist

- [x] Open source (MIT license)
- [x] Public GitHub repo with README and CI
- [x] Placed in Marketing section (most relevant category)
- [x] No duplicate in current list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added ProposalCraft to the marketing section with installation instructions, enabling users to draft voice-matched proposals from past work samples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->