### PR TITLE
Add TWZRD Agent Intel - Solana x402 trust scoring MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [Uniswap PoolSpy](https://github.com/kukapay/uniswap-poolspy-mcp) - An MCP server that tracks newly created liquidity pools on Uniswap across nine blockchain networks.
 - [WhaleTracker MCP](https://github.com/kukapay/whale-tracker-mcp) - A mcp server for tracking cryptocurrency whale transactions.
 - [Yahoo Finance MCP](https://github.com/narumiruna/yfinance-mcp) - Fetches stock data, news, and financial information via a Yahoo Finance API server
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Solana-native AI agent trust scoring via x402 micropayments. Free on-chain preflight checks + paid signed V5 trust receipts settled in <1s. MCP at `https://intel.twzrd.xyz/mcp`.
 - [ZBD](https://github.com/zebedeeio/zbd-mcp-server) - Enables Bitcoin Lightning payments within large language models
 
 ### Gaming


### PR DESCRIPTION
## Summary

- Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **Finance** section
- Solana-native AI agent trust scoring via x402 micropayments
- Free on-chain preflight checks + paid signed V5 trust receipts settled in <1s

## Why it fits

TWZRD Agent Intel is a Solana-based MCP server for agent trust scoring and identity. It belongs in the Finance section alongside other Solana/crypto entries (Jupiter MCP, Solana Agent Kit, Solana Rug Check). It provides:
- On-chain agent trust scoring using Solana's Liquid Attention Protocol (CCM)
- Pay-per-use signed trust receipts via USDC x402 micropayments, settled in <1s
- MCP server at `https://intel.twzrd.xyz/mcp`
- GitHub: https://intel.twzrd.xyz

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Finance section with revised and newly added financial tool entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->