### PR TITLE
Add RunAPI MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [Metoro MCP Server](https://github.com/metoro-io/metoro-mcp-server) - Connects LLMs to Kubernetes clusters via the Claude Desktop App, using Metoro's observability data
 - [Perplexity](https://github.com/ppl-ai/modelcontextprotocol) - A Model Context Protocol Server connector for Perplexity API, to enable web search without leaving the MCP ecosystem.
 - [Riza](https://github.com/riza-io/riza-mcp) - Securely executes and manages LLM-generated code via isolated code interpretation and API tools
+- [RunAPI](https://github.com/runapi-ai/mcp) - Runs AI model jobs through MCP, including image, video, music/audio, and LLM tasks
 - [Tavily](https://github.com/tavily-ai/tavily-mcp) - Enables AI assistants to access real-time web data via advanced search and extraction
 - [Tuning Engines](https://github.com/cerebrixos-org/tuning-engines-cli) - Governs model, agent, skill, and MCP workflows with policy controls, approvals, traces, and usage analytics. Install with `npx -y --package tuningengines-cli@latest te mcp serve`.
 - [ZenML MCP Server](https://github.com/zenml-io/mcp-zenml) - MCP server to connect an MCP client (Cursor, Claude Desktop etc) with your ZenML MLOps and LLMOps pipelines


### PR DESCRIPTION
Added RunAPI to the AI Services section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added RunAPI to the AI Services section of the curated MCP server list. This service supports running AI model jobs for image generation, video processing, audio and music creation, and language model inference tasks through the MCP protocol.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->