### PR TITLE
Add BuyWhere MCP server — real-time SEA product search in Search section

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,6 +566,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [Typesense](https://github.com/suhail-ak-s/mcp-typesense-server) - Provides AI models with access to Typesense search capabilities for data discovery, search, and analysis
 - [Unsplash Image Server](https://github.com/hellokaton/unsplash-mcp-server) - 🔎 A MCP server for Unsplash image search.
 - [WebSearch MCP](https://github.com/pskill9/web-search) - Web search using free google search (NO API KEYS REQUIRED)
+- [BuyWhere](https://github.com/BuyWhere/buywhere-mcp) - Real-time product search and price comparison for Singapore and Southeast Asia. Search 260K+ products from Lazada, Shopee, FairPrice, Courts, and other major SEA merchants.
 
 ### Security
 


### PR DESCRIPTION
## New Server: BuyWhere

Adds [BuyWhere](https://github.com/BuyWhere/buywhere-mcp) to the **Search** section.

**Description:** Real-time product search and price comparison for Singapore and Southeast Asia. Search 260K+ products from Lazada, Shopee, FairPrice, Courts, and other major SEA merchants.

**Features:**
- 260K+ products indexed across Singapore and Southeast Asia
- Real-time price comparison across multiple merchants
- Product availability lookup
- Official implementation by BuyWhere
- MIT License, npm: `@buywhere/mcp-server`

**Quick start:**
```bash
npx -y @buywhere/mcp-server
```
Requires free API key from https://buywhere.ai/api-keys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added BuyWhere MCP server to the Search section documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->