### PR TITLE
Add VideoOverlayKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [Blender](https://github.com/ahujasid/blender-mcp) - AI-powered 3D modeling and scene manipulation tool
 - [Placid.app](https://github.com/felores/placid-mcp-server) - Generate image and video creatives using Placid.app templates in MCP compatible hosts
 - [Rijksmuseum MCP](https://github.com/r-huijts/rijksmuseum-mcp) - Rijksmuseum MCP integration for artwork exploration and analysis
+- [VideoOverlayKit](https://github.com/alichherawalla/video-overlay-kit) - Render 4-6s animated b-roll overlay videos for short-form social (LinkedIn, IG Reels, YouTube Shorts, TikTok) and landscape video. Paste a script, AI writes the scene spec and renders the mp4. Free, MIT, local.
 
 ### Browser Automation
 


### PR DESCRIPTION
Adds [VideoOverlayKit](https://github.com/alichherawalla/video-overlay-kit) — animated b-roll overlay renderer for short-form video. MCP-driven (paste a script, AI writes the scene spec, renders mp4). Free, MIT, runs locally. Live preview: https://alichherawalla.github.io/video-overlay-kit/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added VideoOverlayKit to the Art and Culture section in README, documenting a tool for rendering short-form animated b-roll overlay videos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->