### PR TITLE
Add AccInt to Knowledge and Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 
 ### Knowledge and Memory
 
+- [AccInt](https://github.com/maxbaluev/accreted-intelligence) - Local-first Work Model and MCP server for coding-agent memory across Claude Code, OpenCode, Codex, and Cursor, using a SQLite-backed memory substrate and verified outcome feedback. [Homepage](https://accint.xyz/) | Public integration glue with private engine.
 - [Anki](https://github.com/scorzeth/anki-mcp-server) - Manages and interacts with Anki flashcards via a server, enabling card creation, review, and data retrieval
 - [Apple Notes](https://github.com/RafalWilinski/mcp-apple-notes) - Talk with your notes in Claude. RAG over your Apple Notes using Model Context Protocol.
 - [Basic Memory](https://github.com/basicmachines-co/basic-memory) - Basic Memory is a knowledge management system that allows you to build a persistent semantic graph from conversations with AI assistants. All knowledge is stored in standard Markdown files on your computer, giving you full control and ownership of your data. Integrates directly with Obsidan.md


### PR DESCRIPTION
## Summary

Adds AccInt to the Knowledge and Memory section.

AccInt is a local-first Work Model and MCP server for coding-agent memory across Claude Code, OpenCode, Codex, and Cursor. It uses a SQLite-backed memory substrate and feeds verified outcomes back into future retrieval.

## Notes

The entry links both the public repository and homepage, and explicitly notes the public integration glue / private engine boundary.

## Validation

- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`
- Checked `https://accint.xyz/` and `https://github.com/maxbaluev/accreted-intelligence` return HTTP 200


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added AccInt reference to the Knowledge and Memory list, including GitHub link and description of the MCP server for local-first coding-agent memory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->