### PR TITLE
Add Eulerpool financial data MCP server to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 ### Finance
 
 - [Bankless Onchain](https://github.com/bankless/onchain-mcp) - Bringing the bankless onchain API to MCP
+- [Eulerpool](https://eulerpool.com/financial-data-api/mcp) - Hosted MCP server for institutional-grade financial data: stocks, ETFs, funds, crypto, forex, bonds, and macro (FRED/ECB/IMF/World Bank) via 157+ tools covering fundamentals, analyst estimates, ownership, insider & US-congress trades, and screeners. Free tier.
 - [Financial Datasets](https://github.com/financial-datasets/mcp-server) - An MCP server for interacting with the Financial Datasets stock market API.
 - [Octagon](https://github.com/OctagonAI/octagon-mcp-server) - A free Model Context Protocol (MCP) server that integrates with Octagon API for investment research.
 - [AlphaVantage](https://github.com/calvernaz/alphavantage) - A MCP server for the stock market data API, Alphavantage API.


### PR DESCRIPTION
Adds **Eulerpool** to the Finance section — a hosted MCP server exposing institutional-grade financial data (equities, ETFs, funds, crypto, forex, bonds, macro: FRED/ECB/IMF/World Bank) for AI agents via 157+ tools. Remote: `https://api.eulerpool.com/mcp`. Free tier. https://eulerpool.com/financial-data-api/mcp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Eulerpool to the Finance section with hosted MCP server details and supported financial data/tool coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->