### PR TITLE
Add PostFast to Social Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 ### Social Media
 
 - [Audiense Insights](https://github.com/AudienseCo/mcp-audiense-insights) - Audiense Insights MCP Server is a server based on the Model Context Protocol (MCP) that allows Claude and other MCP-compatible clients to interact with your Audiense Insights account
+- [PostFast](https://github.com/peturgeorgievv-factory/postfast-mcp) - Hosted MCP server to schedule, publish, and analyze social posts across 11 platforms (X, Instagram, TikTok, LinkedIn, YouTube, Threads, Pinterest, Bluesky, Telegram, Facebook, GBP) from Claude/ChatGPT/Cursor. OAuth, 13 tools, no self-host.
 - [Twikit](https://github.com/adhikasp/mcp-twikit) - A Model Context Protocol (MCP) server for interacting with Twitter.
 - [X (Twitter)](https://github.com/EnesCinr/twitter-mcp) - A Model Context Protocol server allows to interact with Twitter, enabling posting tweets and searching Twitter.
 - [X (Twitter)](https://github.com/vidhupv/x-mcp) - Manages and publishes X/Twitter posts via Claude chat


### PR DESCRIPTION
Adds **PostFast** to the **Social Media** category.

[PostFast](https://postfa.st) is a hosted MCP server to schedule, publish, and analyze social posts across 11 platforms (X, Instagram, TikTok, LinkedIn, YouTube, Threads, Pinterest, Bluesky, Telegram, Facebook, Google Business Profile) directly from Claude, ChatGPT, and Cursor. OAuth-based auth, 13 tools, no self-hosting required.

Placed alphabetically in Social Media (after **Audiense Insights**), formatted to match neighboring entries.

- Server repo: https://github.com/peturgeorgievv-factory/postfast-mcp