### PR TITLE
Add NotFair — open-source SEO & paid-ads skills for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 
 ### Marketing
 
+- [NotFair](https://github.com/nowork-studio/NotFair) - Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads. Connects to live account data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP to run audits, keyword research, meta tag optimization, schema markup, and paid-ad management.
 - [Open Strategy Partners Marketing Tools](https://github.com/open-strategy-partners/osp_marketing_tools) - A Model Context Protocol (MCP) server that empowers LLMs to use some of Open Srategy Partners' core writing and product marketing techniques.
 
 ### Monitoring


### PR DESCRIPTION
Hi, thanks for maintaining this list!

I'd like to add [NotFair](https://github.com/nowork-studio/NotFair) to the **Marketing** section. It's an open-source (MIT) set of Claude Code agent skills for SEO, GEO, Google Ads, and Meta Ads — ~2.9k stars on GitHub.

NotFair connects to live account data through the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP, enabling audits, keyword research, meta tag optimization, schema markup generation, and paid-ad management directly from Claude Code.

It fits the Marketing section as a practical MCP-powered tool for marketers and developers. Happy to adjust the description or move it to a different section if you prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new marketing section entry in README describing an open-source set of Claude Code skills for comprehensive SEO and multi-channel digital advertising management. Features include audit capabilities, keyword research, optimization, schema markup support, and integration with multiple data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->