### PR TITLE
Add Memxus to Knowledge and Memory section

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [Basic Memory](https://github.com/basicmachines-co/basic-memory) - Basic Memory is a knowledge management system that allows you to build a persistent semantic graph from conversations with AI assistants. All knowledge is stored in standard Markdown files on your computer, giving you full control and ownership of your data. Integrates directly with Obsidan.md
 - [Goal Story](https://github.com/hichana/goalstory-mcp) - Manages aspirations through narrative-driven goal setting, powered by conversational AI for personalized motivation and progress tracking
 - [Mindmap MCP](https://github.com/YuChenSSR/mindmap-mcp-server) - mindmap, mcp server, artifact
+- [Memxus](https://github.com/gpitrella/memxus-remote-mcp) - Universal persistent memory MCP server. Save context once across Claude Code, Cursor, Gemini CLI and any AI tool — recall it automatically in every session.
 - [Notion](https://github.com/v-3/notion-server) - Seamlessly integrates language models with Notion workspaces for searching, creating, updating, and managing pages and databases
 - [Obsidian Markdown Notes](https://github.com/calclavia/mcp-obsidian) - A connector for Claude Desktop to read and search an Obsidian vault.
 - [PIF](https://github.com/hungryrobot1/MCP-PIF) - A MCP implementation of the personal intelligence framework (PIF)


### PR DESCRIPTION
## Description
Adds Memxus to the Knowledge and Memory section. Memxus is a remote MCP server that provides universal persistent memory across Claude Code, Cursor, Gemini CLI and any MCP-compatible AI tool. Saves context once, recalls it automatically in every session. Connects GitHub + Notion as context sources.

## Type of change
- [x] New MCP server addition
- [ ] Update to existing entry
- [ ] Documentation improvement
- [ ] Other (please describe)

## Checklist
- [x] My entry follows the format: `[Project Name](link) - Description`
- [x] I have added the entry in alphabetical order within its section
- [x] I have verified the link is working
- [x] The project actively implements the Model Context Protocol
- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md)

## Additional Notes
Listed on registry.modelcontextprotocol.io (ID: com.memxus/memxus v1.0.3), Glama, and Smithery. Free tier available at memxus.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new entry in the “Knowledge and Memory” section highlighting Memxus as a persistent memory server that helps retain context across sessions and tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->