### PR TITLE
Add AgentsCoin

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [Bankless Onchain](https://github.com/bankless/onchain-mcp) - Bringing the bankless onchain API to MCP
 - [Financial Datasets](https://github.com/financial-datasets/mcp-server) - An MCP server for interacting with the Financial Datasets stock market API.
 - [Octagon](https://github.com/OctagonAI/octagon-mcp-server) - A free Model Context Protocol (MCP) server that integrates with Octagon API for investment research.
+- [AgentsCoin](https://github.com/axiosdevs/agentscoin-mcp) - Give your AI agent its own money — create a wallet, get AGENT from the faucet, send, and create/trade tokens on a live EVM chain. MCP server + one-click Claude Desktop extension
 - [AlphaVantage](https://github.com/calvernaz/alphavantage) - A MCP server for the stock market data API, Alphavantage API.
 - [Awesome Crypto MCP Servers by badkk](https://github.com/badkk/awesome-crypto-mcp-servers) - A collection of crypto MCP servers.
 - [Bankless Onchain MCP](https://github.com/Bankless/onchain-mcp/) - Bringing the bankless onchain API to MCP


### PR DESCRIPTION
Adds AgentsCoin to the Finance section.

AgentsCoin gives an AI agent its own money on a live EVM chain. The MCP server exposes 8 tools: network_info, create_wallet, mine (faucet, works in chat), balance, send, create_coin, add_liquidity, and swap. There is also a one-click Claude Desktop extension (.mcpb).

- MCP server: https://github.com/axiosdevs/agentscoin-mcp (npx agentscoin-mcp)
- Site: https://agents-coin.com

Single entry, placed alphabetically near the other A entries, matching the existing plain list format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Finance listing for **AgentsCoin**.
  * Included a short description covering agent wallet funding, token sending/trading on a live EVM chain, and one-click Claude Desktop setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->