### PR TITLE
Add Agentlas OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [<div align="center"><img src="https://github.com/user-attachments/assets/211d0c2b-04de-471e-b1ed-97da94a58d82" height="20"/></div>](https://github.com/Upsonic/gpt-computer-assistant) - The most reliable AI agent framework that supports MCP.
 - [ADX MCP Server](https://github.com/pab1it0/adx-mcp-server) - A Model Context Protocol (MCP) server that enables AI assistants to query and analyze Azure Data Explorer databases through standardized interfaces.
 - [AgentMail MCP Toolkit](https://github.com/agentmail-to/agentmail-toolkit/tree/main/mcp) - Manages AgentMail email inboxes via an MCP server, enabling AI-assisted email creation, retrieval, and response
+- [Agentlas OS](https://github.com/agentlas-ai/Agentlas-OS) - Local-first agent runtime exposing MCP tools for building, discovering, and running portable agent and team packages across supported coding hosts
 - [AIQL](https://github.com/AI-QL) - Streamlines AI application development and deployment in cloud-native environments
 - [Airtable MCP Server](https://github.com/domdomegg/airtable-mcp-server) - 🗂️🤖 Airtable Model Context Protocol Server, for allowing AI systems to interact with your Airtable bases
 - [Alibaba Cloud Tablestore MCP Server](https://github.com/aliyun/alibabacloud-tablestore-mcp-server) - Connects Alibaba Cloud Tablestore to large language models via the Model Context Protocol


### PR DESCRIPTION
## Summary

Adds Agentlas OS as a local-first agent runtime exposing MCP tools for building, discovering, and running portable agent and team packages across supported coding hosts.

## Verification

- Rebuilt on current main
- One README entry only
- Preserved the repository existing CRLF line-ending convention

Disclosure: I am submitting this entry on behalf of the Agentlas project.