### PR TITLE
Add FilingFirehose MCP to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 
 - [Bankless Onchain](https://github.com/bankless/onchain-mcp) - Bringing the bankless onchain API to MCP
 - [Financial Datasets](https://github.com/financial-datasets/mcp-server) - An MCP server for interacting with the Financial Datasets stock market API.
+- [FilingFirehose](https://filingfirehose.com) - MCP + REST API over SEC EDGAR filings (8-K, 10-K, 10-Q, S-3) with red-flag risk scoring (going-concern, restatement, cyber, officer departure, dilution). Free tier and per-ticker AI report. Companion open-source classifier at [buried-events-parser](https://github.com/jaablon/buried-events-parser) (MIT).
 - [Octagon](https://github.com/OctagonAI/octagon-mcp-server) - A free Model Context Protocol (MCP) server that integrates with Octagon API for investment research.
 - [AlphaVantage](https://github.com/calvernaz/alphavantage) - A MCP server for the stock market data API, Alphavantage API.
 - [Awesome Crypto MCP Servers by badkk](https://github.com/badkk/awesome-crypto-mcp-servers) - A collection of crypto MCP servers.


### PR DESCRIPTION
Adding FilingFirehose under Finance — a Model Context Protocol server + REST API for SEC EDGAR filings (8-K, 10-K, 10-Q, S-3) with red-flag risk scoring (going-concern, restatement, cyber, officer departure, dilution).

Free tier available. Companion open-source classifier at [buried-events-parser](https://github.com/jaablon/buried-events-parser) (MIT).

Disclosure: I maintain FilingFirehose.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new **FilingFirehose** entry to the Finance section of the README.
  * The entry highlights an EDGAR filings integration with API access and risk-scoring support, plus a link to an open-source classifier resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->