### PR TITLE
Add Skillselion to Other Tools and Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -776,6 +776,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [MCP Chat Client](https://github.com/flux159/mcp-chat) - Open Source Generic MCP Client for testing & evaluating mcp servers and agents
 - [MCP CLI Inspector](https://github.com/wong2/mcp-cli) - A CLI inspector for the Model Context Protocol
 - [MCP Compass](https://github.com/liuyoshio/mcp-compass) - MCP Discovery & Recommendation Service - Find the right MCP server for your needs
+- [Skillselion](https://github.com/skillselion/skillselion-mcp) - Search thousands of community-vetted Claude Code skills, MCP servers and marketplaces from the [Skillselion](https://skillselion.com) catalog (ranked by installs); `load_skill` fetches a real SKILL.md mid-task
 - [MCP Create](https://github.com/tesla0225/mcp-create) - Dynamically creates, manages, and runs Model Context Protocol (MCP) servers
 - [MCP Everything Server](https://github.com/modelcontextprotocol/servers/tree/main/src/everything) - Model Context Protocol Servers
 - [MCP Fetch](https://github.com/modelcontextprotocol/servers/tree/main/src/fetch) - Model Context Protocol Servers


### PR DESCRIPTION
Adds **[Skillselion](https://github.com/skillselion/skillselion-mcp)** near MCP Compass in Other Tools and Integrations — an MCP server that searches thousands of community-vetted Claude Code skills, MCP servers and marketplaces from the [Skillselion](https://skillselion.com) catalog. `load_skill` fetches a real SKILL.md mid-task. One line, existing format followed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “Skillselion” entry to the tools and integrations list.
  * Clarified that it helps find community-vetted Claude Code skills, MCP servers, and marketplaces, and that `load_skill` retrieves the full skill content during a task.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->