### PR TITLE
Add Framesail MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [Firebase MCP](https://github.com/gannonh/firebase-mcp) - Model Context Protocol (MCP) server to interact with Firebase services.
 - [Flipt MCP Server](https://github.com/flipt-io/mcp-server-flipt) - Enables AI assistants to manage Flipt feature flags via the Model Context Protocol
 - [Foxy Contexts](https://github.com/strowk/foxy-contexts) - Foxy contexts is a library for building context servers supporting Model Context Protocol
+- [Framesail](https://framesail.com/developers) - Remote MCP server that turns a script into a finished long-form video end to end: script, locked character/environment references, storyboard, voiceover, animated segments, and MP4 export, with every shot rendered against the same references
 - [Freshdesk AI Agent](https://github.com/effytech/freshdesk_mcp) - MCP server created for Freshdesk, allowing AI models to interact with Freshdesk modules
 - [Gemini Summarizer](https://github.com/0xshellming/mcp-summarizer) - MCP Server for AI Summarization
 - [Gemsuite](https://github.com/PV-Bhat/gemsuite-mcp) - Professional Gemini API integration for Claude and all MCP-compatible hosts with intelligent model selection and advanced file handling | Smithery.ai verified


### PR DESCRIPTION
Adds **Framesail** to the AI Services section (alphabetical, under F).

Framesail is a remote MCP server that turns a script into a finished long-form video end to end — script generation, locked character/environment references, storyboard, voiceover, animated segments, and MP4 export, with every shot rendered against the same references. ~65 tools over a remote streamable-HTTP endpoint with OAuth.

- Endpoint: `https://api.framesail.com/mcp` (streamable HTTP, OAuth 2.0)
- Docs: https://framesail.com/developers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Framesail to the list of AI Services MCP servers.
  * Described its ability to create long-form videos with storyboards, voiceovers, rendering, and MP4 export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->