### PR TITLE
Add RouterBase MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [Metoro MCP Server](https://github.com/metoro-io/metoro-mcp-server) - Connects LLMs to Kubernetes clusters via the Claude Desktop App, using Metoro's observability data
 - [Perplexity](https://github.com/ppl-ai/modelcontextprotocol) - A Model Context Protocol Server connector for Perplexity API, to enable web search without leaving the MCP ecosystem.
 - [Riza](https://github.com/riza-io/riza-mcp) - Securely executes and manages LLM-generated code via isolated code interpretation and API tools
+- [RouterBase MCP](https://github.com/zenlee123/routerbase-mcp) - MCP server for model discovery, pricing lookup, and OpenAI-compatible chat completions through [routerbase](https://routerbase.com).
 - [Tavily](https://github.com/tavily-ai/tavily-mcp) - Enables AI assistants to access real-time web data via advanced search and extraction
 - [Tuning Engines](https://github.com/cerebrixos-org/tuning-engines-cli) - Governs model, agent, skill, and MCP workflows with policy controls, approvals, traces, and usage analytics. Install with `npx -y --package tuningengines-cli@latest te mcp serve`.
 - [ZenML MCP Server](https://github.com/zenml-io/mcp-zenml) - MCP server to connect an MCP client (Cursor, Claude Desktop etc) with your ZenML MLOps and LLMOps pipelines


### PR DESCRIPTION
Adds RouterBase MCP, a Model Context Protocol server for model discovery, pricing lookup, and OpenAI-compatible chat completions through [routerbase](https://routerbase.com).\n\nRepository: https://github.com/zenlee123/routerbase-mcp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added RouterBase MCP to the AI Services section of the Awesome MCP Servers list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->