### PR TITLE
Add Open Index to Knowledge and Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [Mindmap MCP](https://github.com/YuChenSSR/mindmap-mcp-server) - mindmap, mcp server, artifact
 - [Notion](https://github.com/v-3/notion-server) - Seamlessly integrates language models with Notion workspaces for searching, creating, updating, and managing pages and databases
 - [Obsidian Markdown Notes](https://github.com/calclavia/mcp-obsidian) - A connector for Claude Desktop to read and search an Obsidian vault.
+- [Open Index](https://github.com/DrDroidLab/open-index) - Structured context graph for domain-specific agents with hybrid search and validated read/write MCP tools.
 - [PIF](https://github.com/hungryrobot1/MCP-PIF) - A MCP implementation of the personal intelligence framework (PIF)
 - [XMind](https://github.com/apeyroux/mcp-xmind) - Analyzes and queries XMind mind maps, enabling smart searches, task management, and multi-file analysis
 


### PR DESCRIPTION
## Description

Adds Open Index alphabetically under **Knowledge and Memory**. It implements an MCP server for searching and maintaining typed context graphs used by domain-specific agents.

## Type of change

- [x] New MCP server addition

## Checklist

- [x] Entry follows the required Project Name, link, and description format.
- [x] Entry is in alphabetical order within its section.
- [x] Repository link works.
- [x] Project actively implements Model Context Protocol.
- [x] Contribution guidelines reviewed.

## Additional notes

Open Index is MIT-licensed and supports local stdio and remote HTTP MCP deployments. Disclosure: this is an affiliated submission from the Open Index team.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the Open Index MCP server to the Knowledge and Memory section of the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->