### PR TITLE
Add Orkas VideoStudio MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 ### Art and Culture
 
 - [Blender](https://github.com/ahujasid/blender-mcp) - AI-powered 3D modeling and scene manipulation tool
+- [Orkas VideoStudio](https://github.com/Orkas-AI/Orkas-VideoStudio) - Local-first MCP server and CLI for planning and rendering videos from editable timeline files
 - [Placid.app](https://github.com/felores/placid-mcp-server) - Generate image and video creatives using Placid.app templates in MCP compatible hosts
 - [Rijksmuseum MCP](https://github.com/r-huijts/rijksmuseum-mcp) - Rijksmuseum MCP integration for artwork exploration and analysis
 


### PR DESCRIPTION
## Description

Adds the official Orkas VideoStudio repository under Art and Culture as a local-first video-production MCP server and CLI.

## Type of change
- [x] New MCP server addition
- [ ] Update to existing entry
- [ ] Documentation improvement
- [ ] Other

## Checklist
- [x] My entry follows the format: `[Project Name](link) - Description`
- [x] I have added the entry in alphabetical order within its section
- [x] I have verified the link is working
- [x] The project actively implements the Model Context Protocol
- [x] I have read the Contributing Guidelines

## Additional Notes

The entry links to the canonical source repository and does not claim package-registry availability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Art and Culture list to include Orkas VideoStudio between Blender and Placid.app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->