### PR TITLE
Add SandBase CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [Metoro MCP Server](https://github.com/metoro-io/metoro-mcp-server) - Connects LLMs to Kubernetes clusters via the Claude Desktop App, using Metoro's observability data
 - [Perplexity](https://github.com/ppl-ai/modelcontextprotocol) - A Model Context Protocol Server connector for Perplexity API, to enable web search without leaving the MCP ecosystem.
 - [Riza](https://github.com/riza-io/riza-mcp) - Securely executes and manages LLM-generated code via isolated code interpretation and API tools
+- [SandBase CLI](https://github.com/sandbaseai/cli) - Open-source CLI and MCP bridge that connects AI coding agents to 2,000+ AI models and APIs through one account
 - [Tavily](https://github.com/tavily-ai/tavily-mcp) - Enables AI assistants to access real-time web data via advanced search and extraction
 - [Tuning Engines](https://github.com/cerebrixos-org/tuning-engines-cli) - Governs model, agent, skill, and MCP workflows with policy controls, approvals, traces, and usage analytics. Install with `npx -y --package tuningengines-cli@latest te mcp serve`.
 - [ZenML MCP Server](https://github.com/zenml-io/mcp-zenml) - MCP server to connect an MCP client (Cursor, Claude Desktop etc) with your ZenML MLOps and LLMOps pipelines

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [Metoro MCP Server](https://github.com/metoro-io/metoro-mcp-server) - Connects LLMs to Kubernetes clusters via the Claude Desktop App, using Metoro's observability data
 - [Perplexity](https://github.com/ppl-ai/modelcontextprotocol) - A Model Context Protocol Server connector for Perplexity API, to enable web search without leaving the MCP ecosystem.
 - [Riza](https://github.com/riza-io/riza-mcp) - Securely executes and manages LLM-generated code via isolated code interpretation and API tools
-- [SandBase CLI](https://github.com/sandbaseai/cli) - Open-source CLI and MCP bridge that connects AI coding agents to 2,000+ AI models and APIs through one account
+- [SandBase CLI](https://github.com/sandbaseai/cli) - Open-source CLI and MCP bridge that connects AI coding agents to 2,000+ AI models through one account
 - [Tavily](https://github.com/tavily-ai/tavily-mcp) - Enables AI assistants to access real-time web data via advanced search and extraction
 - [Tuning Engines](https://github.com/cerebrixos-org/tuning-engines-cli) - Governs model, agent, skill, and MCP workflows with policy controls, approvals, traces, and usage analytics. Install with `npx -y --package tuningengines-cli@latest te mcp serve`.
 - [ZenML MCP Server](https://github.com/zenml-io/mcp-zenml) - MCP server to connect an MCP client (Cursor, Claude Desktop etc) with your ZenML MLOps and LLMOps pipelines


### PR DESCRIPTION
## Description

Adds [SandBase CLI](https://github.com/sandbaseai/cli) under **AI Services**.

SandBase CLI is an actively maintained Apache-2.0 CLI with an MCP bridge mode. After authorization, it exposes model and API capabilities to Claude Code, Codex, Cursor, and other MCP-compatible AI coding agents, covering 2,000+ AI models through one account.

## Type of change

- [x] New MCP tool addition
- [ ] Update to existing entry
- [ ] Documentation improvement
- [ ] Other

## Checklist

- [x] Entry follows `[Project Name](link) - Description`
- [x] Added in alphabetical order within AI Services
- [x] Canonical repository link verified
- [x] Project actively implements MCP through its documented `mcp-bridge` mode
- [x] Contribution guidelines reviewed

## Disclosure

I am affiliated with SandBase AI. This contribution was prepared with AI assistance and manually reviewed against the repository guidelines and SandBase CLI documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Riza and SandBase CLI to the list of supported AI services.
  * Updated the service listing to retain Tavily after the new entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->