### PR TITLE
Add vatnode — official EU VAT validation MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [Stripe](https://github.com/atharvagupta2003/mcp-stripe) - Manages financial transactions via Stripe, providing secure payment processing, customer management, and refund capabilities with detailed audit logging
 - [TastyTrade Agent](https://github.com/ferdousbhai/tasty-agent) - Let Claude manage your tastytrade portfolio.
 - [Uniswap PoolSpy](https://github.com/kukapay/uniswap-poolspy-mcp) - An MCP server that tracks newly created liquidity pools on Uniswap across nine blockchain networks.
+- [vatnode](https://github.com/vatnode/vatnode-mcp) - Official MCP server for EU VAT validation via VIES, offline VAT rates for 45 European countries, and VAT number format checks.
 - [WhaleTracker MCP](https://github.com/kukapay/whale-tracker-mcp) - A mcp server for tracking cryptocurrency whale transactions.
 - [Yahoo Finance MCP](https://github.com/narumiruna/yfinance-mcp) - Fetches stock data, news, and financial information via a Yahoo Finance API server
 - [ZBD](https://github.com/zebedeeio/zbd-mcp-server) - Enables Bitcoin Lightning payments within large language models


### PR DESCRIPTION
Adds the official vatnode MCP server to the Finance section.

### What it does
- Validates EU VAT numbers against the EU Commission's VIES service
- Returns registered company name, address, registration date, and an optional consultation number (audit-grade proof of validation)
- Looks up VAT rates for all 45 European jurisdictions, fully offline
- Checks VAT number format against country-specific regex patterns

### Quick facts
- Actively maintained, MIT licensed
- npm: https://www.npmjs.com/package/vatnode-mcp
- Source: https://github.com/vatnode/vatnode-mcp
- Install: `npx -y vatnode-mcp`

### Disclosure
I maintain this project (I'm the author of vatnode and vatnode-mcp).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added the `vatnode` MCP server to the Finance section.
  - Documented EU VAT validation, offline VAT rates for 45 European countries, and VAT number format checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->