### PR TITLE
Add Pocket Drives to Travel and Transportation

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,6 +634,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 
 - [FlightRadar24](https://github.com/sunsetcoder/flightradar24-mcp-server) - Model Context Protocol server for Flight Tracking
 - [NS Travel Information MCP Server](https://github.com/r-huijts/ns-mcp-server) - A Model Context Protocol (MCP) server that provides access to NS (Dutch Railways) travel information through Claude AI. This server enables Claude to fetch real-time train travel information and disruptions using the official Dutch NS API.
+- [Pocket Drives](https://github.com/RevList/pocket-drives-mcp) - Remote MCP to search peer-to-peer luxury, exotic, and EV rentals from independent hosts. Booking finishes in the iOS app.
 - [Travel Planner](https://github.com/GongRzhe/TRAVEL-PLANNER-MCP-Server) - Provides travel planning functionalities like location search, route calculation, and time zone retrieval via Google Maps APIs
 
 ### Version Control


### PR DESCRIPTION
## Summary
Adds [Pocket Drives](https://github.com/RevList/pocket-drives-mcp) under **Travel and Transportation**, alphabetically after NS Travel Information MCP Server and before Travel Planner.

Remote MCP for searching peer-to-peer luxury, exotic, and EV rentals from independent hosts. Booking finishes in the iOS app. Endpoint: `https://pocketdrives.ai/mcp`.

## Checklist
- [x] Entry follows existing format (`- [Name](url) - description`)
- [x] Placed alphabetically within Travel and Transportation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Pocket Drives to the Travel and Transportation listings.
  * Included a link to its MCP repository and details about searching and booking luxury, exotic, and electric vehicle rentals through the iOS app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->