### PR TITLE
Add CCS MCP Server to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,6 +589,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [Descope](https://github.com/descope-sample-apps/descope-mcp-server) - Provides a server interface for interacting with Descope's Management APIs to search and retrieve project information
 - [DNStwist MCP Server](https://github.com/BurtTheCoder/mcp-dnstwist) - MCP server for dnstwist, a powerful DNS fuzzing tool that helps detect typosquatting, phishing, and corporate espionage.
 - [DomScan](https://github.com/estevecastells/domscan-mcp) - MCP server for domain intelligence: availability, DNS, WHOIS/RDAP, SSL, subdomains, valuation, email security and typosquatting/brand protection.
+- [CCS MCP Server](https://github.com/DSHCorrectover/ccs-mcp-server) - Runtime verification middleware for AI agent tool calls. 7-dimension checks (Structure/Schema/Latency/Cost/Identity/Integrity/Security), Ed25519-signed receipts, sub-millisecond P50, zero dependencies. IETF draft + PyPI/GitHub Action ecosystem.
 - [Maigret MCP Server](https://github.com/BurtTheCoder/mcp-maigret) - MCP server for maigret, a powerful OSINT tool that collects user account information from various public sources.
 - [MCP Guardian](https://github.com/eqtylab/mcp-guardian) - Manage / Proxy / Secure your MCP Servers
 - [MCP Security Auditor](https://github.com/qianniuspace/mcp-security-audit) - A powerful MCP (Model Context Protocol) Server that audits npm package dependencies for security vulnerabilities. Built with remote npm registry integration for real-time security checks.


### PR DESCRIPTION
## Summary

Add CCS (Correctover Conformance Shape) MCP Server — runtime verification middleware for AI agent tool calls.

## What it does

Sits between LLM decision and tool execution. Every tool call (allowed or blocked) produces a 22-field Ed25519-signed receipt covering 7 verification dimensions: Structure, Schema, Latency, Cost, Identity, Integrity, Security. Sub-millisecond P50 (~2.7μs Node core verifier), zero dependencies, fully offline.

## Links

- npm: https://www.npmjs.com/package/ccs-mcp-server (v1.2.4, zero deps)
- PyPI: https://pypi.org/project/ccs-verifier (v1.1.16, 157 tests)
- GitHub Action: https://github.com/DSHCorrectover/ccs-verifier-action
- Demo (6 scenarios, zero deps): https://github.com/DSHCorrectover/ccs-demo
- Zenodo DOI: 10.5281/zenodo.22055351

## Changes

Single-line addition to the Security section, alphabetically after DomScan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the CCS MCP Server to the Security section.
  * Documented runtime tool-call verification, signed receipts, performance, and ecosystem integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->