### PR TITLE
Add Live Tennis API MCP to Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [Jupiter MCP](https://github.com/kukapay/jupiter-mcp) - An MCP server for executing token swaps on the Solana blockchain using Jupiter's new Ultra API.
 - [KukaPay Uniswap Trader](https://github.com/kukapay/uniswap-trader-mcp) - An MCP server for AI agents to automate token swaps on Uniswap DEX across multiple blockchains.
 - [LedgerAI](https://github.com/minhyeoky/mcp-server-ledger) - A Model Context Protocol server for interacting with Ledger CLI, a powerful double-entry accounting system. This server enables Large Language Models to query and analyze financial data through a standardized interface, making it easy for AI assistants to help with financial reporting, budget analysis, and accounting tasks.
+- [Live Tennis API](https://github.com/livetennisapi/livetennisapi-mcp) - Live tennis match state (score, current server, three-valued break-point flag, retirement/walkover/completed) plus player rankings, Elo, and fixtures, for enriching event-market strategies. Free tier, no card required.
 - [PancakeSwap PoolSpy](https://github.com/kukapay/pancakeswap-poolspy-mcp) - An MCP server that tracks newly created liquidity pools on Pancake Swap
 - [Stripe](https://github.com/atharvagupta2003/mcp-stripe) - Manages financial transactions via Stripe, providing secure payment processing, customer management, and refund capabilities with detailed audit logging
 - [TastyTrade Agent](https://github.com/ferdousbhai/tasty-agent) - Let Claude manage your tastytrade portfolio.


### PR DESCRIPTION
Adds one MCP server to the **Finance** section.

**Disclosure:** I run the Live Tennis API — judge on the merits. Submitting because the section already lists market-data feeds (CoinPaprika, CryptoPanic News, Yahoo Finance, Financial Datasets) alongside trading tooling, and this fills a genuine gap: live tennis match-state that AI agents use to enrich event-market (Polymarket/Kalshi) strategies. It is a read-only DATA feed — never a venue or execution adapter.

What it exposes over MCP: live score, current server, a three-valued break-point flag (true / false / undefined in tiebreaks or on null), and terminal states (retirement / walkover / completed), plus player rankings and Elo and fixtures. Coverage runs ATP/WTA/Challenger/ITF/juniors, with strength on deep draws where generic feeds are thin.

Details:
- MCP package: `livetennisapi-mcp`, listed on the official MCP Registry as `io.github.livetennisapi/livetennisapi-mcp`.
- Actively maintained, documented, implements the Model Context Protocol.
- Free tier available with no card required.

Entry added (alphabetical placement, between `LedgerAI` and `PancakeSwap PoolSpy`):

```markdown
- [Live Tennis API](https://github.com/livetennisapi/livetennisapi-mcp) - Live tennis match state (score, current server, three-valued break-point flag, retirement/walkover/completed) plus player rankings, Elo, and fixtures, for enriching event-market strategies. Free tier, no card required.
```

Checklist per CONTRIBUTING.md: actively maintained, implements MCP, documented, format `- [Project Name](link) - Brief description`, alphabetical order preserved within the section, no duplicate entry, link verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the Live Tennis API MCP server to the Finance section.
  * Documented access to live match data, player statistics, fixtures, and the available free tier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->