### PR TITLE
Add VidWords YouTube MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [DeepResearch Assistant](https://github.com/reading-plus-ai/mcp-server-deep-research) - Generates comprehensive, well-cited research reports from a given research question
 - [Oorlogsbronnen AI](https://github.com/r-huijts/oorlogsbronnen-mcp) - MCP server for accessing Dutch World War II archives through the Oorlogsbronnen API. Provides structured access to historical records, photographs, and documents from 1940-1945 Netherlands.
 - [SimplePubMed](https://github.com/andybrandt/mcp-simple-pubmed) - MCP server for searching and querying PubMed medical papers/research database
+- [VidWords](https://github.com/haljishi/vidwords-mcp) - Hosted YouTube MCP server for searching transcripts across a whole channel, reading captions, and analysing a video's frames, returning answers with citable timestamps
 - [World Bank data API](https://github.com/anshumax/world_bank_mcp_server) - An implementation of the Model Context Protocol for the World Bank open data API
 
 ### Search


### PR DESCRIPTION
### What this adds

One row under **Research and Data**, in alphabetical position before `World Bank data API`.

```
- [VidWords](https://github.com/haljishi/vidwords-mcp) - Hosted YouTube MCP server for searching transcripts across a whole channel, reading captions, and analysing a video's frames, returning answers with citable timestamps
```

### Why Research and Data

The section already collects servers that let a model search and cite a body of source material — arXiv, PubMed, Dutch WWII archives, World Bank. This is the same job for video: `search_transcript` takes a **list** of videos, so one call answers a question across a whole channel and comes back with clickable timestamp citations rather than a wall of transcript. A model cannot watch a video, but it can read a transcript with timestamps it is able to cite.

Happy to move it if you would rather file it elsewhere.

### Details

- Endpoint: `https://vidwords.com/mcp` — remote Streamable HTTP
- Auth: OAuth 2.1 with dynamic client registration and PKCE; a static token also works for CI and headless agents
- Official MCP registry: `com.vidwords/youtube`, `status: active`
- Nine tools: `search_transcript`, `get_transcript`, `list_channel_videos`, `analyze_video`, `get_analysis`, `ask_video`, `list_watchlists`, `watchlist_activity`, `account`
- The repo carries the README, `server.json`, client configs for Claude Desktop, Claude Code, Cursor and Codex, and an agent skill

### Disclosure

I maintain VidWords. There is a free tier and it needs no card.
