### PR TITLE
Add Wine Labs MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [TastyTrade Agent](https://github.com/ferdousbhai/tasty-agent) - Let Claude manage your tastytrade portfolio.
 - [Uniswap PoolSpy](https://github.com/kukapay/uniswap-poolspy-mcp) - An MCP server that tracks newly created liquidity pools on Uniswap across nine blockchain networks.
 - [WhaleTracker MCP](https://github.com/kukapay/whale-tracker-mcp) - A mcp server for tracking cryptocurrency whale transactions.
+- [Wine Labs](https://github.com/imiraoui/winelabs-mcp) - Fine-wine identity matching, pricing, auction and exchange research, merchant comparisons, portfolios, and cellar workflows. Hosted Streamable HTTP at `https://chat.wine-labs.com/mcp` with browser OAuth.
 - [Yahoo Finance MCP](https://github.com/narumiruna/yfinance-mcp) - Fetches stock data, news, and financial information via a Yahoo Finance API server
 - [ZBD](https://github.com/zebedeeio/zbd-mcp-server) - Enables Bitcoin Lightning payments within large language models
 

--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [TastyTrade Agent](https://github.com/ferdousbhai/tasty-agent) - Let Claude manage your tastytrade portfolio.
 - [Uniswap PoolSpy](https://github.com/kukapay/uniswap-poolspy-mcp) - An MCP server that tracks newly created liquidity pools on Uniswap across nine blockchain networks.
 - [WhaleTracker MCP](https://github.com/kukapay/whale-tracker-mcp) - A mcp server for tracking cryptocurrency whale transactions.
-- [Wine Labs](https://github.com/imiraoui/winelabs-mcp) - Fine-wine identity matching, pricing, auction and exchange research, merchant comparisons, portfolios, and cellar workflows. Hosted Streamable HTTP at `https://chat.wine-labs.com/mcp` with browser OAuth.
+- [Wine Labs](https://winelabs.ai/agents) - Fine-wine identity matching, pricing, auction and exchange research, merchant comparisons, portfolios, and cellar workflows. Hosted Streamable HTTP at `https://chat.wine-labs.com/mcp` with browser OAuth. [Public metadata](https://github.com/imiraoui/winelabs-mcp).
 - [Yahoo Finance MCP](https://github.com/narumiruna/yfinance-mcp) - Fetches stock data, news, and financial information via a Yahoo Finance API server
 - [ZBD](https://github.com/zebedeeio/zbd-mcp-server) - Enables Bitcoin Lightning payments within large language models
 


### PR DESCRIPTION
## Summary

- Adds the official Wine Labs hosted MCP server to Financial Services.
- Documents the Streamable HTTP endpoint and browser OAuth accurately.
- Links the canonical [Wine Labs MCP product page](https://winelabs.ai/agents) while retaining public connection metadata and installation documentation.

## Verification

- Public MCP endpoint returns the expected OAuth challenge.
- OAuth protected-resource discovery, product, install, privacy, and terms URLs return HTTP 200.

This is a maintainer self-submission prepared with an automated coding agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Wine Labs MCP server entry in the Finance section of the README.
  * Linked the entry to the Wine Labs agents page.
  * Added a separate “Public metadata” reference to the GitHub repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->