### PR TITLE
Add Process Street MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,6 +684,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [NotionMCP](https://github.com/danhilse/notion_mcp) - A simple MCP integration that allows Claude to read and manage a personal Notion todo list
 - [NTFY-MCP Notifier](https://github.com/teddyzxcv/ntfy-mcp) - Sends ntfy notifications upon Model Context Protocol task completion
 - [Pipedream MCP](https://github.com/PipedreamHQ/pipedream/tree/master/modelcontextprotocol) - Connect APIs, remarkably fast.  Free for developers.
+- [Process Street MCP Server](https://github.com/process-street/process-street-mcp) - Connects AI clients to Process Street workflows, workflow runs, tasks, users, data sets, and operational records.
 - [Productboard](https://github.com/kenjihikmatullah/productboard-mcp) - Integrate the Productboard API into agentic workflows via MCP
 - [Rootly MCP Integration](https://github.com/Rootly-AI-Labs/Rootly-MCP-server) - Integrates Rootly with MCP-compatible IDEs for rapid incident resolution
 - [Salesforce MCP Integrator](https://github.com/lciesielski/mcp-salesforce-example) - Integrates with Salesforce via the Model Context Protocol (MCP) to send emails and deploy Apex code


### PR DESCRIPTION
## Description

Adds Process Street's official hosted MCP server to Workflow Automation. It connects AI clients to Process Street workflows, workflow runs, tasks, users, data sets, and operational records.

Public repository: https://github.com/process-street/process-street-mcp
Documentation: https://www.process.st/help/docs/mcp-server/
Hosted endpoint: https://mcp.process.st/

## Type of change

- [x] New MCP server addition
- [ ] Update to existing entry
- [ ] Documentation improvement
- [ ] Other

## Checklist

- [x] My entry follows the format: `[Project Name](link) - Description`
- [x] I have added the entry in alphabetical order within its section
- [x] I have verified the link is working
- [x] The project actively implements the Model Context Protocol
- [x] I have read the Contributing Guidelines

## Additional Notes

This is a first-party submission for Process Street's remote Streamable HTTP server. It is also published in the Official MCP Registry as `io.github.process-street/process-street-mcp` version `1.0.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the Process Street MCP Server to the Workflow Automation resources list.
  * Described its ability to connect AI clients with workflows, tasks, runs, users, data sets, and operational records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->