### PR TITLE
Add BulkPublish MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,6 +608,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [Twikit](https://github.com/adhikasp/mcp-twikit) - A Model Context Protocol (MCP) server for interacting with Twitter.
 - [X (Twitter)](https://github.com/EnesCinr/twitter-mcp) - A Model Context Protocol server allows to interact with Twitter, enabling posting tweets and searching Twitter.
 - [X (Twitter)](https://github.com/vidhupv/x-mcp) - Manages and publishes X/Twitter posts via Claude chat
+- [BulkPublish](https://github.com/azeemkafridi/bulkpublish-api) - API and MCP server for AI-agent social media planning, scheduling, publishing, media, and analytics. [Documentation](https://app.bulkpublish.com/docs)
 
 ### System Automation
 


### PR DESCRIPTION
Adds BulkPublish to the Social Media category. BulkPublish provides an API and MCP server for AI agents to plan, adapt, review, schedule, publish, and analyze social media content. Documentation: https://app.bulkpublish.com/docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added BulkPublish to the Social Media integrations list.
  * Documented support for AI-agent social media planning, scheduling, publishing, media management, and analytics.
  * Added a link to the BulkPublish documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->