### PR TITLE
Add Lodestar Stamp to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,6 +589,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [Descope](https://github.com/descope-sample-apps/descope-mcp-server) - Provides a server interface for interacting with Descope's Management APIs to search and retrieve project information
 - [DNStwist MCP Server](https://github.com/BurtTheCoder/mcp-dnstwist) - MCP server for dnstwist, a powerful DNS fuzzing tool that helps detect typosquatting, phishing, and corporate espionage.
 - [DomScan](https://github.com/estevecastells/domscan-mcp) - MCP server for domain intelligence: availability, DNS, WHOIS/RDAP, SSL, subdomains, valuation, email security and typosquatting/brand protection.
+- [Lodestar Stamp](https://lodestarstamp.com) - Agent trust layer: a dated receipt on a named entity. Any agent calls before it acts. REST lookup plus MCP discovery card. We attest; we do not approve the booking. Lookup free through 2026.
 - [Maigret MCP Server](https://github.com/BurtTheCoder/mcp-maigret) - MCP server for maigret, a powerful OSINT tool that collects user account information from various public sources.
 - [MCP Guardian](https://github.com/eqtylab/mcp-guardian) - Manage / Proxy / Secure your MCP Servers
 - [MCP Security Auditor](https://github.com/qianniuspace/mcp-security-audit) - A powerful MCP (Model Context Protocol) Server that audits npm package dependencies for security vulnerabilities. Built with remote npm registry integration for real-time security checks.


### PR DESCRIPTION
Add Lodestar Stamp under Security — connectable MCP (stdio + remote), not a discovery-card paste.

## Connect
- **Remote (Streamable HTTP):** `https://api.lodestarindex.com/mcp`
- **stdio:** `npx -y lodestar-stamp-mcp@0.1.9`
- Site / docs: https://lodestarstamp.com · https://lodestarstamp.com/docs
- Discovery card (not an MCP endpoint): https://lodestarstamp.com/.well-known/mcp.json — do **not** paste into `~/.cursor/mcp.json`

## Example `mcp.json` (remote)
```json
{
  "mcpServers": {
    "lodestar-stamp": {
      "url": "https://api.lodestarindex.com/mcp"
    }
  }
}
```

## What it does
Dated public-source receipts (identity, address, license, inspection) agents fetch before they act. Facts on the record. We do not approve the booking. Lookup free through 2026. Chicago restaurants beachhead.

Tools: `get_receipt`, `batch_receipts`, `find_business`, `list_markets`, `list_index`, `list_sources`, `list_gaps`.

Contact: watch@lodestarstamp.com

Resubmit note: prior Awesome-MCP #39 was rejected for card≠MCP; live `/mcp` + npm package now connectable (Gate B #242 PASS).

