### PR TITLE
Add Agent QA MCP server to developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 <img src="https://user-images.githubusercontent.com/74038190/225813708-98b745f2-7d22-48cf-9150-083f1b00d6c9.gif" width="500">
 <br><br>
 
+- [Agent QA](https://github.com/vostride/agent-qa) - Source-available MCP server for authoring and inspecting natural-language web and mobile tests.
 - [APIMatic MCP](https://github.com/apimatic/apimatic-validator-mcp) - APIMatic Validator MCP Server for validating OpenAPI specs via APIMatic's API with MCP
 - [Comet Opik MCP](https://github.com/comet-ml/opik-mcp) - Model Context Protocol (MCP) implementation for Opik enabling seamless IDE integration and unified access to prompts, projects, traces, and metrics.
 - [JetBrains](https://github.com/JetBrains/mcp-jetbrains) - A model context protocol server to work with JetBrains IDEs: IntelliJ, PyCharm, WebStorm, etc. Also, works with Android Studio


### PR DESCRIPTION
## Description

Add Agent QA to Developer Tools as a source-available MCP server for authoring and inspecting natural-language web and mobile application tests.

The current repository ships `@vostride/agent-qa-mcp`, depends on the official Model Context Protocol SDK, and connects through `StdioServerTransport`. Its CLI exposes `agent-qa mcp`, and the server registers authoring, validation, run-enqueueing, and triage tools. Source: https://github.com/vostride/agent-qa/tree/main/packages/mcp

## Type of change

- [x] New MCP server addition
- [ ] Update to existing entry
- [ ] Documentation improvement
- [ ] Other (please describe)

## Checklist

- [x] My entry follows the format: `[Project Name](link) - Description`
- [x] I have added the entry in alphabetical order within its section
- [x] I have verified the link is working
- [x] The project actively implements the Model Context Protocol
- [x] I have read the Contributing Guidelines

## Additional Notes

The diff adds exactly one line and preserves every original byte, including the README's mixed line endings. `git -c core.whitespace=cr-at-eol diff --check` passes. No duplicate entry or proposal was found.

Disclosure: I am affiliated with Agent QA/Vostride; AI assisted this contribution. Agent QA uses FSL-1.1-ALv2 and is source-available. Each release converts to Apache-2.0 after two years. Permitted use has no package fee; configured model, browser, and device providers may charge separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added the Agent QA MCP server to the Developer Tools section of the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->