### PR TITLE
Add ParlayAPI to Gaming MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,7 @@ A curated list of Model Context Protocol (MCP) servers and tools. MCP is an open
 - [ObsidianMCP](https://github.com/StevenStavrakis/obsidian-mcp) - A simple MCP server for Obsidian
 - [Open-Sourced MCP Servers Directory](https://github.com/chatmcp/mcp-directory) - directory for Awesome MCP Servers
 - [OpenDota](https://github.com/asusevski/opendota-mcp-server) - Provides real-time Dota 2 statistics and match data via a Model Context Protocol server
+- [ParlayAPI](https://github.com/JacobiusMakes/parlay-api-mcp) - Sports odds, player props, public event discovery, and account usage through a Python stdio server; account data tools use each user's own API key and allowances.
 - [SimpleMCP](https://github.com/ribeirogab/simple-mcp) - A simple TypeScript library for creating MCP servers.
 - [Unity Integration (Advanced)](https://github.com/quazaai/UnityMCPIntegration) - Enable AI Agents to Control Unity
 


### PR DESCRIPTION
## Description

Adds ParlayAPI alphabetically in Gaming alongside the existing sports entry. I maintain the public Python stdio MCP server for sports odds, player props, public event discovery and account usage. Account data tools require each user's own API key and allowances.

## Type of change
- [x] New MCP server addition
- [ ] Update to existing entry
- [ ] Documentation improvement
- [ ] Other

## Checklist
- [x] Entry follows `[Project Name](link) - Description`
- [x] Entry is in alphabetical order within its section
- [x] Source link returns 200
- [x] Project actively implements MCP
- [x] Read the contribution guidelines

## Additional Notes

No duplicate was found in current entries or issues/PRs. The published command passed MCP initialization and discovery of 22 tools without account calls. No native-client attestation is claimed. The file's existing CRLF line endings are preserved; whitespace validation passes with `core.whitespace=cr-at-eol`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added the ParlayAPI MCP server to the Gaming resources section, highlighting sports odds, player props, public event discovery, and account usage capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->